### PR TITLE
Update dfgproposal.cls

### DIFF
--- a/dfgproposal.cls
+++ b/dfgproposal.cls
@@ -284,7 +284,7 @@
 		
 		\vspace{9ex}
 		
-		{\renewcommand{\and}{\\[1em]\GetTranslation{and}\\[1em]}
+		{\renewcommand{\and}{\vspace*{1em}\GetTranslation{and}\\[1em]}
 			\@author
 		}
 		

--- a/dfgproposal.cls
+++ b/dfgproposal.cls
@@ -284,7 +284,7 @@
 		
 		\vspace{9ex}
 		
-		{\renewcommand{\and}{\vspace*{1em}\GetTranslation{and}\\[1em]}
+		{\renewcommand{\and}{\par\vspace{1em}\GetTranslation{and}\par\vspace{1em}}
 			\@author
 		}
 		


### PR DESCRIPTION
The change makes the compilation more tolerant towards additional line breaks in the 'author' part of the titel page and prevents errors such as:

Fix 'No line to end here' when compiling the document